### PR TITLE
incude <string.h> for compile errors

### DIFF
--- a/src/convert_wav_files.cpp
+++ b/src/convert_wav_files.cpp
@@ -13,7 +13,6 @@
 //     - clear and detailed warning and error messages
 
 #include "convert_wav_files.h"
-
 #include "configuration.h"
 #include "lame_init.h"
 #include "return_code.h"
@@ -32,6 +31,7 @@
 #include <set>
 #include <sstream>
 #include <tuple>
+#include <string.h>
 
 #define ERROR_PREFIX "   [ ERROR ] "
 #define OK_PREFIX "   [  OK   ] "

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -5,6 +5,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string.h>
 
 using namespace std;
 


### PR DESCRIPTION
During compile errors like:

```
/home/rvl/devel/cpp/wav2mp3/src/convert_wav_files.cpp:506:13: error: there are no arguments to ‘strlen’ that depend on a template parameter, so a declaration of ‘strlen’ must be available [-fpermissive]
  506 |         if (strlen(tag_string_raw.get()) >= (std::size_t)data_size) {
```
and
```
/home/rvl/devel/cpp/wav2mp3/src/guid.cpp:61:16: error: ‘memcmp’ was not declared in this scope
   61 |            && (memcmp(a.node, b.node, sizeof(a.node)) == 0);
```
Pupped up. These are functions defined in <string.h> So this PR includes:
#include <string.h> in aforementioned files.